### PR TITLE
Add .circleci/config.yml

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,9 @@
+version: 2.1
+
+orbs:
+  maven: circleci/maven@0.0.12
+
+workflows:
+  maven_test:
+    jobs:
+      - maven/test # checkout, build, test, and upload test results

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,3 +14,25 @@ jobs:
     
 docker:
       - image: circleci/openjdk:8-jdk-stretch
+     
+steps:
+
+      - checkout
+
+      - restore_cache:
+          key: TicketingRest-{{ checksum "pom.xml" }}
+      
+      - run: mvn dependency:go-offline
+      
+      - save_cache:
+          paths:
+            - ~/.m2
+          key: TicketingRest-{{ checksum "pom.xml" }}
+      
+      - run: mvn package
+      
+      - store_test_results:
+          path: target/surefire-reports
+      
+      - store_artifacts:
+          path: target/TicketingRest-0.0.1-SNAPSHOT.jar

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2 # use CircleCI 2.0
 jobs: # a collection of steps
   build: # runs not using Workflows must have a `build` job as entry point
     
-    working_directory: ~/TicketingRest # directory where steps will run
+    working_directory: ~/work/TicketingRest # directory where steps will run
 
     docker: # run the steps with Docker
       - image: circleci/openjdk:8-jdk-stretch # ...with this image as the primary container; this is where all `steps` will run

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2 # use CircleCI 2.0
 jobs: # a collection of steps
   build: # runs not using Workflows must have a `build` job as entry point
     
-    working_directory: ~/work/TicketingRest # directory where steps will run
+    working_directory: ~/TicketingRest # directory where steps will run
 
     docker: # run the steps with Docker
       - image: circleci/openjdk:8-jdk-stretch # ...with this image as the primary container; this is where all `steps` will run

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2 # use CircleCI 2.0
 jobs: # a collection of steps
   build: # runs not using Workflows must have a `build` job as entry point
     
-    working_directory: ~/TicketingRest # directory where steps will run
+    working_directory: TicketingRest # directory where steps will run
 
     docker: # run the steps with Docker
       - image: circleci/openjdk:8-jdk-stretch # ...with this image as the primary container; this is where all `steps` will run

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,8 +4,8 @@ jobs: # a collection of steps
     
     working_directory: TicketingRest # directory where steps will run
 
-    docker: # run the steps with Docker
-      - image: circleci/openjdk:8-jdk-stretch # ...with this image as the primary container; this is where all `steps` will run
+    #docker: # run the steps with Docker
+      #- image: circleci/openjdk:8-jdk-stretch # ...with this image as the primary container; this is where all `steps` will run
 
     steps: # a collection of executable commands
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,38 +1,35 @@
-version: 2.1
-
-orbs:
-  maven: circleci/maven@0.0.12
-
-workflows:
-  maven_test:
-    jobs:
-      - maven/test # checkout, build, test, and upload test results
-      
-jobs:
-  build:
-    working_directory: ~/TicketingRest
+version: 2 # use CircleCI 2.0
+jobs: # a collection of steps
+  build: # runs not using Workflows must have a `build` job as entry point
     
-docker:
-      - image: circleci/openjdk:8-jdk-stretch
-     
-steps:
+    working_directory: ~/TicketingRest # directory where steps will run
 
-      - checkout
+    docker: # run the steps with Docker
+      - image: circleci/openjdk:8-jdk-stretch # ...with this image as the primary container; this is where all `steps` will run
 
-      - restore_cache:
+    steps: # a collection of executable commands
+
+      - checkout # check out source code to working directory
+
+      - restore_cache: # restore the saved cache after the first run or if `pom.xml` has changed
+          # Read about caching dependencies: https://circleci.com/docs/2.0/caching/
           key: TicketingRest-{{ checksum "pom.xml" }}
       
-      - run: mvn dependency:go-offline
+      - run: mvn dependency:go-offline # gets the project dependencies
       
-      - save_cache:
+      - save_cache: # saves the project dependencies
           paths:
             - ~/.m2
           key: TicketingRest-{{ checksum "pom.xml" }}
       
-      - run: mvn package
+      - run: mvn package # run the actual tests
       
-      - store_test_results:
+      - store_test_results: # uploads the test metadata from the `target/surefire-reports` directory so that it can show up in the CircleCI dashboard. 
+      # Upload test results for display in Test Summary: https://circleci.com/docs/2.0/collect-test-data/
           path: target/surefire-reports
       
-      - store_artifacts:
+      - store_artifacts: # store the uberjar as an artifact
+      # Upload test summary for display in Artifacts: https://circleci.com/docs/2.0/artifacts/
           path: target/TicketingRest-0.0.1-SNAPSHOT.jar
+      # See https://circleci.com/docs/2.0/deployment-integrations/ for deploy examples
+

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,8 +4,8 @@ jobs: # a collection of steps
     
     working_directory: TicketingRest # directory where steps will run
 
-    #docker: # run the steps with Docker
-      #- image: circleci/openjdk:8-jdk-stretch # ...with this image as the primary container; this is where all `steps` will run
+    docker: # run the steps with Docker
+      - image: circleci/openjdk:9.0.1-11-jdk # ...with this image as the primary container; this is where all `steps` will run
 
     steps: # a collection of executable commands
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,3 +7,10 @@ workflows:
   maven_test:
     jobs:
       - maven/test # checkout, build, test, and upload test results
+      
+jobs:
+  build:
+    working_directory: ~/TicketingRest
+    
+docker:
+      - image: circleci/openjdk:8-jdk-stretch


### PR DESCRIPTION
version: 2 # use CircleCI 2.0
jobs: # a collection of steps
  build: # runs not using Workflows must have a `build` job as entry point
    
    working_directory: ~/circleci-demo-java-spring # directory where steps will run

    docker: # run the steps with Docker
      - image: circleci/openjdk:8-jdk-stretch # ...with this image as the primary container; this is where all `steps` will run

    steps: # a collection of executable commands

      - checkout # check out source code to working directory

      - restore_cache: # restore the saved cache after the first run or if `pom.xml` has changed
          # Read about caching dependencies: https://circleci.com/docs/2.0/caching/
          key: circleci-demo-java-spring-{{ checksum "pom.xml" }}
      
      - run: mvn dependency:go-offline # gets the project dependencies
      
      - save_cache: # saves the project dependencies
          paths:
            - ~/.m2
          key: circleci-demo-java-spring-{{ checksum "pom.xml" }}
      
      - run: mvn package # run the actual tests
      
      - store_test_results: # uploads the test metadata from the `target/surefire-reports` directory so that it can show up in the CircleCI dashboard. 
      # Upload test results for display in Test Summary: https://circleci.com/docs/2.0/collect-test-data/
          path: target/surefire-reports
      
      - store_artifacts: # store the uberjar as an artifact
      # Upload test summary for display in Artifacts: https://circleci.com/docs/2.0/artifacts/
          path: target/demo-java-spring-0.0.1-SNAPSHOT.jar
      # See https://circleci.com/docs/2.0/deployment-integrations/ for deploy examples  